### PR TITLE
Adding measure tool to interface

### DIFF
--- a/lib/Views/UserInterface.jsx
+++ b/lib/Views/UserInterface.jsx
@@ -6,6 +6,8 @@ import StandardUserInterface from 'terriajs/lib/ReactViews/StandardUserInterface
 import MenuItem from 'terriajs/lib/ReactViews/StandardUserInterface/customizable/MenuItem';
 import RelatedMaps from './RelatedMaps';
 import { Menu } from 'terriajs/lib/ReactViews/StandardUserInterface/customizable/Groups';
+import { Nav } from 'terriajs/lib/ReactViews/StandardUserInterface/customizable/Groups';
+import MeasureTool from 'terriajs/lib/ReactViews/Map/Navigation/MeasureTool';
 
 import './global.scss';
 
@@ -16,6 +18,9 @@ export default function UserInterface(props) {
                 <RelatedMaps viewState={props.viewState} />
                 <MenuItem caption="About" href="about.html" key="about-link"/>
             </Menu>
+            <Nav>
+                <MeasureTool terria={props.viewState.terria} key="measure-tool"/>
+            </Nav>
         </StandardUserInterface>
     );
 }


### PR DESCRIPTION
This adds the measure tool (distances only). However, due to some CSS changes, you're going to need to upgrade to a version of TerriaJS with PR #1876 merged, otherwise the icon will be floating in a weird way towards the centre of the map.